### PR TITLE
Handle profile slugs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -29,6 +29,9 @@ RewriteRule ^datingtips-verenigd-koninkrijk/?$ datingtips.php?item=uk [L,QSA]
 RewriteRule ^datingtips-oostenrijk/?$ datingtips.php?item=at [L,QSA]
 RewriteRule ^datingtips-zwitserland/?$ datingtips.php?item=ch [L,QSA]
 
+# Profile slugs
+RewriteRule ^shemale-([a-z0-9-]+)/?$ profile.php?slug=$1 [L,QSA]
+
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME}.php -f

--- a/includes/header.php
+++ b/includes/header.php
@@ -131,6 +131,10 @@
     if($profile_img){
       $ogImage = $profile_img;
     }
+  } elseif(isset($_GET['slug'])){
+    $slugParam = filter_var($_GET['slug'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+    $canonical = 'https://shemaledaten.net/shemale-' . $slugParam;
+    $pageTitle = 'Shemale ' . $slugParam . ' | shemaledaten.net';
   }
 
   echo '<link rel="canonical" href="' . $canonical . '" >';

--- a/js/profile.js
+++ b/js/profile.js
@@ -17,6 +17,11 @@ function slugify(str){
         .replace(/-+$/, '');
 }
 
+function getSlugFromPath(){
+    var match = window.location.pathname.match(/^\/shemale-([^\/]+)$/);
+    return match ? match[1] : null;
+}
+
 var profiel= new Vue({
     router,
     el: "#profiel",
@@ -25,15 +30,20 @@ var profiel= new Vue({
         if(!id){
             id = getQueryParam('id');
         }
+        var slug = typeof profile_slug !== 'undefined' && profile_slug ? profile_slug : getSlugFromPath();
         if(1*id > 0){
             this.profile_id = 1*id;
             this.init();
+        } else if(slug){
+            this.profile_slug = slug;
+            this.init();
         }
-        console.log(this.profile_id);
+        console.log(this.profile_id, this.profile_slug);
     },
     data: {
         profile_id: 0,
-        profile: { name : '', 
+        profile_slug: '',
+        profile: { name : '',
                   city : '',
                   profile_image_big : '',
                   aboutme : '',
@@ -48,11 +58,15 @@ var profiel= new Vue({
     },
     methods:  {
         init: function(){
-            if(this.profile_id <= 0){
+            if(this.profile_id <= 0 && !this.profile_slug){
                 return;
             }
             let that= this;
-            axios.get(api_url + this.profile_id)
+            var url = api_url + this.profile_id;
+            if(this.profile_slug && this.profile_id <= 0){
+                url = api_url + '?slug=' + encodeURIComponent(this.profile_slug);
+            }
+            axios.get(url)
                 .then(function(response){
                     that.profile = response.data.profile;
                     if(that.profile.profile_image_big && that.profile.profile_image_big.indexOf('no_img_Vrouw.jpg') !== -1){

--- a/profile.php
+++ b/profile.php
@@ -62,6 +62,7 @@ $base = __DIR__;
 <script>
   var api_url = "<?= $api_url ?>";
   var ref_id = "<?= $ref_id ?>"; //de ref_id vd landingwebsite
+  var profile_slug = "<?= isset($_GET['slug']) ? htmlspecialchars($_GET['slug'], ENT_QUOTES, 'UTF-8') : '' ?>";
 </script>
 
 <?php 


### PR DESCRIPTION
## Summary
- add rewrite rule so `/shemale-<slug>` loads `profile.php`
- handle `slug` parameter in `header.php`
- expose `profile_slug` variable to JS
- allow loading a profile by slug in `js/profile.js`

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6851a0a73fac8324b6653de49d852d8d