### PR TITLE
Fix canonical URL generation

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -102,7 +102,7 @@
           break;
       }
     } else {
-      $item = preg_replace('/^sexdate-/', '', $item);
+      $item = preg_replace('/^(?:sexdate|shemale)-/', '', $item);
       $canonical = 'https://shemaledaten.net/shemale-' . $item;
       $pageTitle = 'Shemale ' . $item . ' | shemaledaten.net';
       if(isset($province['img'])){


### PR DESCRIPTION
## Summary
- prevent duplicate prefix when generating canonical URLs for province pages

## Testing
- `php -l includes/header.php` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa462a8308324a97e968bdc48b04d